### PR TITLE
Corrige erro ao enviar corpo de requisição vazio e adiciona o status 204 ao checar se resposta foi sucedida

### DIFF
--- a/gerencianet/pix/requester_pix.go
+++ b/gerencianet/pix/requester_pix.go
@@ -70,9 +70,7 @@ func (requester requester) request(endpoint string, httpVerb string, requestPara
 	route := getRoute(endpoint, requestParams)
 	route += getQueryString(requestParams)
 
-	var req *http.Request
 	var requestBody io.Reader
-
 	if body != nil {
 		requestBodyBytes := new(bytes.Buffer)
 		err := json.NewEncoder(requestBodyBytes).Encode(body)
@@ -81,8 +79,7 @@ func (requester requester) request(endpoint string, httpVerb string, requestPara
 		}
 		requestBody = requestBodyBytes
 	}
-
-	req, _ = http.NewRequest(httpVerb, requester.url+route, requestBody)
+	req, _ := http.NewRequest(httpVerb, requester.url+route, requestBody)
 
 	if ( httpVerb == "POST" || httpVerb == "PUT" ) && body != nil  {
 		req.Header.Add("Content-Type", "application/json")


### PR DESCRIPTION
descobri que se enviarmos um body vazio no endpoint [/v2/gn/split/cob/:txid/vinculo/:splitConfigId](https://dev.gerencianet.com.br/docs/api-pix-endpoints#vincular-uma-cobran%C3%A7a-a-um-split-de-pagamento) a API retorna erro 500, mas se enviarmos nil ela retorna normalmente, então fiz essa alteração para tratar este caso

esse endpoint também retorna 204 em sucesso, que não estava mapeado na condição dos status